### PR TITLE
Add RunPod usage docs and refine service

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,39 @@ For more questions/discussions feel free to stop by **#nanoGPT** on Discord:
 ## acknowledgements
 
 All nanoGPT experiments are powered by GPUs on [Lambda labs](https://lambdalabs.com), my favorite Cloud GPU provider. Thank you Lambda labs for sponsoring nanoGPT!
+
+## RunPod cloud jobs
+
+RunPod offers cheap and fast GPUs for training and inference. First install the
+`runpod` Python package:
+
+```sh
+pip install runpod
+```
+
+Set your API key as an environment variable:
+
+```sh
+export RUNPOD_API_KEY="<your key>"
+```
+
+### Training
+
+Launch a training pod with a config file:
+
+```sh
+python runpod_service.py train config/my_config.py
+```
+
+Use `--gpu` to choose a GPU type id if you want something other than the default
+NVIDIA A100.
+
+### Inference
+
+Once you deploy an inference endpoint on RunPod, run:
+
+```sh
+python runpod_service.py infer "Hello" --endpoint <ENDPOINT_ID>
+```
+
+If `--endpoint` is omitted, the script reads `RUNPOD_ENDPOINT_ID`.

--- a/runpod_service.py
+++ b/runpod_service.py
@@ -1,0 +1,91 @@
+import os
+import time
+import runpod
+
+
+DEFAULT_IMAGE = "runpod/pytorch:2.2.1-cuda12.1-devel"
+DEFAULT_GPU = "NVIDIA A100 40GB PCIe"
+
+
+class RunpodError(Exception):
+    """Custom exception for RunPod operations."""
+
+
+def start_cloud_training(config_path: str, gpu_type: str = DEFAULT_GPU) -> str:
+    """Launch a training job on RunPod and stream status to the console.
+
+    Args:
+        config_path: Path to the training config file.
+        gpu_type: GPU type to request.
+
+    Returns:
+        The created pod ID.
+    """
+    api_key = os.getenv("RUNPOD_API_KEY")
+    if not api_key:
+        raise RunpodError("RUNPOD_API_KEY environment variable is required")
+
+    runpod.api_key = api_key
+
+    pod = runpod.create_pod(
+        name="nanogpt-training",
+        image_name=DEFAULT_IMAGE,
+        gpu_type_id=gpu_type,
+        gpu_count=1,
+        start_ssh=True,
+        docker_args=f"python train.py {config_path}",
+    )
+    pod_id = pod.get("id")
+    if not pod_id:
+        raise RunpodError("Failed to create pod")
+
+    print(f"Created pod {pod_id}")
+
+    while True:
+        info = runpod.get_pod(pod_id)
+        status = info.get("desiredStatus") or info.get("podStatus") or info.get("state")
+        print(f"Training status: {status}")
+        if status in {"COMPLETED", "STOPPED", "FAILED", "TERMINATED"}:
+            break
+        time.sleep(10)
+
+    return pod_id
+
+
+def run_inference(prompt: str, endpoint_id: str | None = None):
+    """Run inference on a RunPod endpoint and print the output."""
+    endpoint_id = endpoint_id or os.getenv("RUNPOD_ENDPOINT_ID")
+    if not endpoint_id:
+        raise RunpodError("Endpoint id must be provided or RUNPOD_ENDPOINT_ID set")
+
+    api_key = os.getenv("RUNPOD_API_KEY")
+    if not api_key:
+        raise RunpodError("RUNPOD_API_KEY environment variable is required")
+
+    runpod.api_key = api_key
+    endpoint = runpod.Endpoint(endpoint_id)
+    result = endpoint.run_sync({"input": prompt})
+    output = result.get("output", result)
+    print(output)
+    return output
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="RunPod helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    t = sub.add_parser("train", help="Start training job")
+    t.add_argument("config", help="Training config file")
+    t.add_argument("--gpu", default=DEFAULT_GPU, help="GPU type id")
+
+    i = sub.add_parser("infer", help="Run inference")
+    i.add_argument("prompt", help="Prompt text")
+    i.add_argument("--endpoint", help="RunPod endpoint id")
+
+    args = parser.parse_args()
+    if args.cmd == "train":
+        start_cloud_training(args.config, args.gpu)
+    else:
+        run_inference(args.prompt, args.endpoint)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from model import GPT, GPTConfig
+
+
+def test_model_forward():
+    config = GPTConfig(vocab_size=10, block_size=4, n_layer=2, n_head=2, n_embd=8)
+    model = GPT(config)
+    x = torch.randint(0, 10, (1, 4))
+    out, _ = model(x, targets=x)
+    assert out.shape == (1, 4, 10)

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -1,0 +1,56 @@
+import types
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import runpod_service as rp
+
+
+class DummyEndpoint:
+    def __init__(self, endpoint_id):
+        self.endpoint_id = endpoint_id
+        self.called = False
+
+    def run_sync(self, data):
+        self.called = True
+        return {"output": "ok"}
+
+
+def test_run_inference(monkeypatch):
+    dummy = DummyEndpoint("123")
+    monkeypatch.setattr(
+        rp, "runpod", types.SimpleNamespace(Endpoint=lambda x: dummy, api_key=None)
+    )
+    monkeypatch.setenv("RUNPOD_API_KEY", "key")
+    result = rp.run_inference("hi", endpoint_id="123")
+    assert result == "ok"
+    assert dummy.called
+
+
+def test_start_cloud_training(monkeypatch):
+    created = {}
+
+    def fake_create_pod(**kwargs):
+        created.update(kwargs)
+        return {"id": "pod123"}
+
+    statuses = [{"state": "STARTING"}, {"state": "STOPPED"}]
+
+    def fake_get_pod(pod_id):
+        return statuses.pop(0)
+
+    monkeypatch.setenv("RUNPOD_API_KEY", "key")
+    monkeypatch.setattr(
+        rp,
+        "runpod",
+        types.SimpleNamespace(
+            create_pod=fake_create_pod,
+            get_pod=fake_get_pod,
+            Endpoint=None,
+            api_key=None,
+        ),
+    )
+    monkeypatch.setattr(rp.time, "sleep", lambda x: None)
+    pod_id = rp.start_cloud_training("config.py")
+    assert pod_id == "pod123"
+    assert "docker_args" in created and "config.py" in created["docker_args"]


### PR DESCRIPTION
## Summary
- document how to launch training and inference with RunPod
- print only inference output from RunPod API
- adjust unit test for new inference return value

## Testing
- `ruff check runpod_service.py tests/test_model.py tests/test_runpod_service.py`
- `mypy --ignore-missing-imports runpod_service.py tests/test_model.py tests/test_runpod_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ec7fcd30832992730b2b59eec254