### PR TITLE
Add DAG ops and float tokenizer

### DIFF
--- a/binary_embedding.py
+++ b/binary_embedding.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 class BinaryAwareEmbedding(nn.Module):
     """Embedding that appends numeric tag information."""
 
-    def __init__(self, vocab_size: int, embed_dim: int, binary_dim: int = 8):
+    def __init__(self, vocab_size: int, embed_dim: int, binary_dim: int = 32):
         super().__init__()
         self.vocab_size = vocab_size
         self.embed_dim = embed_dim

--- a/dag_model.py
+++ b/dag_model.py
@@ -11,11 +11,23 @@ def add(x, y):
     return x + y
 
 
+def multiply(x, y):
+    return x * y
+
+
+def subtract(x, y):
+    return x - y
+
+
+def divide(x, y, eps: float = 1e-8):
+    return x / (y + eps)
+
+
 def identity(x, _unused=None):
     return x
 
 
-op_funcs = [add, identity]
+op_funcs = [add, identity, multiply, subtract, divide]
 
 
 class DAGController(nn.Module):
@@ -55,7 +67,7 @@ class DifferentiableDAG(nn.Module):
             input1, input2, op_weights = self.controller(node_tensor)
             results = []
             for i, op in enumerate(op_funcs):
-                out = op(input1, input2 if i == 0 else None)
+                out = op(input1, input2)
                 results.append(op_weights[i] * out)
             new_node = sum(results)
             nodes.append(new_node)
@@ -74,7 +86,7 @@ from binary_embedding import BinaryAwareEmbedding
 class DAGGPTConfig(GPTConfig):
     dag_steps: int = 4
     dag_hidden_dim: int = 16
-    dag_num_ops: int = 2
+    dag_num_ops: int = 5
 
 
 class DAGGPT(GPT):
@@ -89,7 +101,7 @@ class DAGGPT(GPT):
 
     def forward(self, idx, binary=None, targets=None):
         if binary is None:
-            binary = torch.zeros(idx.size(0), idx.size(1), 9, device=idx.device)
+            binary = torch.zeros(idx.size(0), idx.size(1), 33, device=idx.device)
         device = idx.device
         b, t = idx.size()
         pos = torch.arange(0, t, dtype=torch.long, device=device)

--- a/tests/test_dag_model.py
+++ b/tests/test_dag_model.py
@@ -2,14 +2,22 @@ import torch
 import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from dag_model import DAGGPT, DAGGPTConfig, DifferentiableDAG, DAGController
+from dag_model import (
+    DAGGPT,
+    DAGGPTConfig,
+    DifferentiableDAG,
+    DAGController,
+    multiply,
+    subtract,
+    divide,
+)
 
 
 def test_dag_gpt_forward():
     config = DAGGPTConfig(vocab_size=20, block_size=4, n_layer=1, n_head=1, n_embd=8, dag_steps=2)
     model = DAGGPT(config)
     x = torch.randint(0, 20, (1, 4))
-    binary = torch.zeros(1, 4, 9)
+    binary = torch.zeros(1, 4, 33)
     logits, loss, dag_out = model(x, binary=binary)
     assert logits.shape == (1, 4, 20)
     assert dag_out.shape[-1] == config.n_embd
@@ -28,3 +36,11 @@ def test_dag_node_growth_regression():
     out = dag([torch.ones(4)])
     assert out.shape == (3, 4)
     assert torch.allclose(out[-1], torch.full((4,), 4.0))
+
+
+def test_op_functions():
+    x = torch.tensor([2.0, 3.0])
+    y = torch.tensor([1.0, 2.0])
+    assert torch.allclose(multiply(x, y), x * y)
+    assert torch.allclose(subtract(x, y), x - y)
+    assert torch.allclose(divide(x, y), x / y)

--- a/tests/test_numeric_tokenizer.py
+++ b/tests/test_numeric_tokenizer.py
@@ -6,16 +6,16 @@ def test_numeric_encoding():
     tokens, binary = tok.encode("7 plus 3")
     assert len(tokens) == len(binary)
     decoded = tok.decode(tokens)
-    assert "7" in decoded
+    assert "7.0" in decoded
 
 
 def test_tokenizer_roundtrip_regression():
     tok = NumericTokenizer()
     text = "12 and 34"
     tokens, binary = tok.encode(text)
-    assert all(len(vec) == 9 for vec in binary)
+    assert all(len(vec) == 33 for vec in binary)
     decoded = tok.decode(tokens)
-    assert decoded == text
+    assert decoded == "12.0 and 34.0"
 
 
 def test_tokenizer_id_stability():


### PR DESCRIPTION
## Summary
- support multiply/subtract/divide in `dag_model`
- store float representations in `NumericTokenizer`
- increase binary vector width to 33
- adjust DAGGPT and embedding sizes
- update unit tests

## Testing
- `pytest -q` 

------
https://chatgpt.com/codex/tasks/task_e_684b9dc7e7c88329a514802a9b20406d