### PR TITLE
Reduce test runtime

### DIFF
--- a/tests/test_dag_model.py
+++ b/tests/test_dag_model.py
@@ -12,11 +12,17 @@ from dag_model import (
     subtract,
     divide,
 )
+import pytest
 
 
-def test_dag_gpt_forward():
+@pytest.fixture(scope="module")
+def small_dag_gpt():
     config = DAGGPTConfig(vocab_size=20, block_size=4, n_layer=1, n_head=1, n_embd=8, dag_depth=2)
-    model = DAGGPT(config)
+    return DAGGPT(config), config
+
+
+def test_dag_gpt_forward(small_dag_gpt):
+    model, config = small_dag_gpt
     x = torch.randint(0, 20, (1, 4))
     binary = torch.zeros(1, 4, 33)
     logits, loss, dag_out = model(x, binary=binary)
@@ -48,9 +54,8 @@ def test_op_functions():
     assert torch.allclose(divide(x, y), x / y)
 
 
-def test_dag_backward_flow():
-    config = DAGGPTConfig(vocab_size=20, block_size=4, n_layer=1, n_head=1, n_embd=8, dag_depth=2)
-    model = DAGGPT(config)
+def test_dag_backward_flow(small_dag_gpt):
+    model, _ = small_dag_gpt
     x = torch.randint(0, 20, (1, 4))
     binary = torch.zeros(1, 4, 33)
     _, _, dag_out = model(x, binary=binary)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,11 +4,17 @@ import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from model import GPT, GPTConfig
+import pytest
 
 
-def test_model_forward():
+@pytest.fixture(scope="module")
+def small_gpt():
     config = GPTConfig(vocab_size=10, block_size=4, n_layer=2, n_head=2, n_embd=8)
-    model = GPT(config)
+    return GPT(config)
+
+
+def test_model_forward(small_gpt):
+    model = small_gpt
     x = torch.randint(0, 10, (1, 4))
     out, _ = model(x, targets=x)
     assert out.shape == (1, 4, 10)

--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -4,11 +4,17 @@ import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from model import GPT, GPTConfig
+import pytest
 
 
-def test_parameter_count_positive():
+@pytest.fixture(scope="module")
+def simple_model():
     config = GPTConfig(vocab_size=10, block_size=4, n_layer=1, n_head=1, n_embd=8)
-    model = GPT(config)
+    return GPT(config)
+
+
+def test_parameter_count_positive(simple_model):
+    model = simple_model
     count = model.get_num_params()
     assert isinstance(count, int)
     assert count > 0

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -1,7 +1,6 @@
 import types
 import os
 import sys
-import runpod
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import runpod_service as rp


### PR DESCRIPTION
## Summary
- lazily import `runpod` only when needed
- speed up tests by caching models with module-scoped fixtures
- avoid importing `runpod` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dddbae1f88329add429be23538aed