### PR TITLE
Add DAG attention visualization

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ runpod
 numpy==1.26.4
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.0+cpu
+matplotlib

--- a/runpod_service.py
+++ b/runpod_service.py
@@ -2,11 +2,6 @@ import os
 import time
 from typing import Sequence
 
-import torch
-import matplotlib.pyplot as plt
-
-from numeric_tokenizer import NumericTokenizer
-from dag_model import DAGGPT
 runpod = None
 
 
@@ -89,8 +84,8 @@ def run_inference(prompt: str, endpoint_id: str | None = None):
 
 
 def visualize_dag_attention(
-    model: DAGGPT,
-    tokenizer: NumericTokenizer,
+    model,
+    tokenizer,
     prompt: str,
     save_path: str = "dag_attention.png",
 ):
@@ -106,12 +101,22 @@ def visualize_dag_attention(
         The path to the saved image.
     """
 
+    import torch
+    import matplotlib.pyplot as plt
+    from dag_model import DAGGPT
+    from numeric_tokenizer import NumericTokenizer
+
+    if not isinstance(model, DAGGPT):
+        raise TypeError("model must be DAGGPT")
+    if not isinstance(tokenizer, NumericTokenizer):
+        raise TypeError("tokenizer must be NumericTokenizer")
+
     tokens, binary = tokenizer.encode(prompt)
     x = torch.tensor(tokens).unsqueeze(0)
     b = torch.tensor(binary).unsqueeze(0)
     model.eval()
     with torch.no_grad():
-        logits, _, _, dag_info = model(x, binary=b, return_dag_info=True)
+        _, _, _, dag_info = model(x, binary=b, return_dag_info=True)
 
     attn_history: Sequence[torch.Tensor] = dag_info["attn"]
     max_len = max(t.numel() for t in attn_history)

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -83,3 +83,37 @@ def test_start_cloud_training_default_config(monkeypatch):
     pod_id = rp.start_cloud_training("config/train_chatgpt2.py")
     assert pod_id == "pod123"
     assert "config/train_chatgpt2.py" in created.get("docker_args", "")
+
+
+def test_visualize_dag_attention(tmp_path):
+    from dag_model import DAGGPT, DAGGPTConfig, DAGController
+    from numeric_tokenizer import NumericTokenizer
+    import torch
+
+    class DummyController(DAGController):
+        def forward(self, nodes):
+            self.last_attn = torch.tensor([1.0, 0.0])
+            input1 = nodes[0]
+            input2 = nodes[1]
+            self.last_op_weights = torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0])
+            return input1, input2, self.last_op_weights
+
+    tok = NumericTokenizer()
+    prompt = "2 3"
+    tokens, binary = tok.encode(prompt)
+    cfg = DAGGPTConfig(
+        vocab_size=tok.next_id,
+        block_size=len(tokens),
+        n_layer=1,
+        n_head=1,
+        n_embd=4,
+        dag_depth=1,
+    )
+    model = DAGGPT(cfg)
+    model.dag.controller = DummyController(cfg.n_embd, cfg.dag_num_ops)
+    out_path = tmp_path / "viz.png"
+    result = rp.visualize_dag_attention(model, tok, prompt, save_path=str(out_path))
+    assert os.path.exists(result)
+    assert torch.allclose(model.dag.controller.last_attn, torch.tensor([1.0, 0.0]))
+    assert torch.argmax(model.dag.controller.last_op_weights).item() == 2
+


### PR DESCRIPTION
## Summary
- track DAG controller attention and op weights
- allow returning DAG info from models
- provide helper to plot DAG attention heatmaps
- add tests for the new visualization helper
- include matplotlib in dev requirements

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684def23cc9c8329941a8324068b9e51