### PR TITLE
Add dataclass-based configuration for training

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import subprocess
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def test_train_script_runs(tmp_path):
+    prep_script = os.path.join(REPO_ROOT, 'data', 'shakespeare_char', 'prepare.py')
+    subprocess.check_call([sys.executable, prep_script])
+
+    train_script = os.path.join(REPO_ROOT, 'train.py')
+    config_file = os.path.join(REPO_ROOT, 'config', 'train_default.py')
+
+    cmd = [
+        sys.executable,
+        train_script,
+        config_file,
+        f'--out_dir={tmp_path}',
+        '--device=cpu',
+        '--compile=False',
+        '--eval_interval=1',
+        '--eval_iters=1',
+        '--log_interval=1',
+        '--max_iters=0',
+         '--dataset=shakespeare_char',
+        '--batch_size=2',
+        '--n_layer=1',
+        '--n_head=1',
+        '--n_embd=32',
+        '--block_size=32',
+    ]
+    subprocess.check_call(cmd, cwd=REPO_ROOT)


### PR DESCRIPTION
## Summary
- replace globals configuration pattern with structured `TrainConfig`
- load config files and CLI overrides without using `exec`
- keep test ensuring `train.py` runs with minimal settings

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f7f4a74688329a6349115ad4bb3c2