### PR TITLE
Default training uses tiny CPU config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.4
 
 It is a good idea to benchmark your interconnect (e.g. iperf3). In particular, if you don't have Infiniband then also prepend `NCCL_IB_DISABLE=1` to the above launches. Your multinode training will work, but most likely _crawl_. By default checkpoints are periodically written to the `--out_dir`. We can sample from the model by simply `python sample.py`.
 
-Finally, to train on a single GPU simply run the `python train.py` script. When no configuration file is supplied it defaults to `config/train_default.py`. Have a look at all of its args, the script tries to be very readable, hackable and transparent. You'll most likely want to tune a number of those variables depending on your needs.
+Finally, you can quickly test things by simply running `python train.py`.
+When no configuration file is supplied it defaults to `config/train_default.py`,
+a tiny CPU-based configuration that mirrors the settings used in the tests.
+Have a look at all of its args&mdash;the script tries to be very readable,
+hackable and transparent. You'll most likely want to tune a number of those
+variables depending on your needs or switch to a GPU oriented config for serious
+training.
 
 ## baselines
 
@@ -249,14 +255,15 @@ export RUNPOD_API_KEY="<your key>"
 
 ### Training
 
-Launch a training pod with the default config:
+Launch a training pod with the default CPU config:
 
 ```sh
 python runpod_service.py train config/train_default.py
 ```
 
 Or simply use `train.py` with `--use-runpod`. Any extra arguments are forwarded
-to the cloud job. Without a config argument this uses `config/train_default.py`:
+to the cloud job. Without a config argument this uses `config/train_default.py`
+(the tiny CPU setup):
 
 ```sh
 python train.py --use-runpod --dag-depth 4

--- a/config/train_default.py
+++ b/config/train_default.py
@@ -1,26 +1,28 @@
-# Default training configuration used when no config file is provided.
+"""Minimal CPU configuration used by default when running ``train.py``."""
 import torch
 
-out_dir = 'out'
-eval_interval = 250
+# evaluate every step and run a single iteration by default
+out_dir = "out"
+eval_interval = 1
 log_interval = 1
-eval_iters = 200
+eval_iters = 1
 eval_only = False
 always_save_checkpoint = True
-init_from = 'scratch'
+init_from = "scratch"
 
 wandb_log = False
-wandb_project = 'owt'
-wandb_run_name = 'gpt2'
+wandb_project = "owt"
+wandb_run_name = "gpt2"
 
-dataset = 'openwebtext'
-gradient_accumulation_steps = 5 * 8
-batch_size = 12
-block_size = 1024
+# tiny dataset and network for quick local testing
+dataset = "shakespeare_char"
+gradient_accumulation_steps = 1
+batch_size = 2
+block_size = 32
 
-n_layer = 12
-n_head = 12
-n_embd = 768
+n_layer = 1
+n_head = 1
+n_embd = 32
 dropout = 0.0
 bias = False
 
@@ -29,7 +31,7 @@ dag_hidden_dim = 16
 dag_num_ops = 5
 
 learning_rate = 6e-4
-max_iters = 600000
+max_iters = 0
 weight_decay = 1e-1
 beta1 = 0.9
 beta2 = 0.95
@@ -40,7 +42,7 @@ warmup_iters = 2000
 lr_decay_iters = 600000
 min_lr = 6e-5
 
-backend = 'nccl'
-device = 'cuda'
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16'
-compile = True
+backend = "gloo"
+device = "cpu"
+dtype = "float32"
+compile = False


### PR DESCRIPTION
## Summary
- default `train.py` now loads a minimal CPU configuration
- note CPU config in README
- update RunPod section to mention the tiny setup

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8d5981d48329976f5753f305ed70