### PR TITLE
Fix DAGGPT bugs

### DIFF
--- a/tests/test_daggpt_bugs.py
+++ b/tests/test_daggpt_bugs.py
@@ -1,0 +1,29 @@
+import torch
+import pytest
+
+from dag_model import DAGGPT, DAGGPTConfig, DAGController
+
+
+def test_controller_selects_distinct_inputs():
+    torch.manual_seed(0)
+    controller = DAGController(hidden_dim=4, num_ops=5)
+    nodes = torch.randn(1, 3, 4)
+    input1, input2, _ = controller(nodes)
+    assert not torch.allclose(input1, input2)
+
+
+def test_weight_tying():
+    cfg = DAGGPTConfig(vocab_size=10, block_size=4, n_layer=1, n_head=1, n_embd=8, dag_depth=1)
+    model = DAGGPT(cfg)
+    w1 = model.transformer.wte.embedding.weight
+    w2 = model.lm_head.weight
+    assert w1.data_ptr() == w2.data_ptr()
+
+
+def test_forward_block_size_assertion():
+    cfg = DAGGPTConfig(vocab_size=10, block_size=2, n_layer=1, n_head=1, n_embd=8, dag_depth=1)
+    model = DAGGPT(cfg)
+    x = torch.randint(0, 10, (1, 3))
+    binary = torch.zeros(1, 3, 33)
+    with pytest.raises(AssertionError):
+        model(x, binary=binary)


### PR DESCRIPTION
## Summary
- compute two independent attention distributions for DAGController
- tie embedding and LM head weights in DAGGPT
- validate block size in DAGGPT forward
- add regression tests for DAGController and DAGGPT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9f1183f48329b58042f7fbe39f6b