### PR TITLE
Refactor train test to avoid network download

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,33 +1,54 @@
 import os
 import sys
 import subprocess
+import numpy as np
+import pickle
 
 REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 
 def test_train_script_runs(tmp_path):
-    prep_script = os.path.join(REPO_ROOT, 'data', 'shakespeare_char', 'prepare.py')
-    subprocess.check_call([sys.executable, prep_script])
+    """Run ``train.py`` on a tiny synthetic dataset to ensure the script works."""
+    # Create a minimal dataset locally to avoid network downloads from prepare.py
+    data_dir = tmp_path / "data" / "shakespeare_char"
+    data_dir.mkdir(parents=True)
 
-    train_script = os.path.join(REPO_ROOT, 'train.py')
-    config_file = os.path.join(REPO_ROOT, 'config', 'train_default.py')
+    vocab_size = 10
+    block_size = 32
+
+    # Generate a very small token stream just long enough for ``get_batch``
+    arr = np.arange(block_size + 2, dtype=np.uint16) % vocab_size
+    arr.tofile(data_dir / "train.bin")
+    arr.tofile(data_dir / "val.bin")
+
+    meta = {
+        "vocab_size": vocab_size,
+        "itos": {i: str(i) for i in range(vocab_size)},
+        "stoi": {str(i): i for i in range(vocab_size)},
+    }
+    with open(data_dir / "meta.pkl", "wb") as f:
+        pickle.dump(meta, f)
+
+    train_script = os.path.join(REPO_ROOT, "train.py")
+    config_file = os.path.join(REPO_ROOT, "config", "train_default.py")
 
     cmd = [
         sys.executable,
         train_script,
         config_file,
-        f'--out_dir={tmp_path}',
-        '--device=cpu',
-        '--compile=False',
-        '--eval_interval=1',
-        '--eval_iters=1',
-        '--log_interval=1',
-        '--max_iters=0',
-         '--dataset=shakespeare_char',
-        '--batch_size=2',
-        '--n_layer=1',
-        '--n_head=1',
-        '--n_embd=32',
-        '--block_size=32',
+        f"--out_dir={tmp_path / 'out'}",
+        "--device=cpu",
+        "--compile=False",
+        "--eval_interval=1",
+        "--eval_iters=1",
+        "--log_interval=1",
+        "--max_iters=0",
+        "--dataset=shakespeare_char",
+        "--batch_size=2",
+        "--n_layer=1",
+        "--n_head=1",
+        "--n_embd=32",
+        "--block_size=32",
     ]
-    subprocess.check_call(cmd, cwd=REPO_ROOT)
+    # Run the training script in ``tmp_path`` so it picks up the synthetic dataset
+    subprocess.check_call(cmd, cwd=tmp_path)


### PR DESCRIPTION
## Summary
- avoid network downloads in `test_train.py` by generating a tiny synthetic dataset on the fly
- keep same script invocation while running faster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbf2097d08329b0296bf67cae892d