### PR TITLE
Add new ops to DAG and simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ previous nodes and chooses simple operations such as addition and subtraction
 (see `dag_model.py`). The `DAGGPT` model runs the transformer while preserving a
 copy of the input embeddings. A separate DAG stream operates on this copy and
 its final node is decoded back to a numeric token.
-The module implements basic ops (`add`, `multiply`, `subtract`, `divide`, `identity`) and learns to compose them via attention.
+The module implements basic ops (`add`, `multiply`, `subtract`, `divide`, `identity`,
+`power`, `log`, `max`, `min`) and learns to compose them via attention.
 The experiment evaluates whether this reasoning layer improves performance on small arithmetic problems.
 
 ## Architecture

--- a/config/eval_daggpt_runpod.py
+++ b/config/eval_daggpt_runpod.py
@@ -8,4 +8,3 @@ init_from = 'resume'
 
 dag_depth = 4
 dag_hidden_dim = 16
-dag_num_ops = 5

--- a/config/train_daggpt_runpod.py
+++ b/config/train_daggpt_runpod.py
@@ -16,7 +16,6 @@ n_embd = 768
 
 dag_depth = 4
 dag_hidden_dim = 16
-dag_num_ops = 5
 
 # 300B tokens
 max_iters = 600000

--- a/config/train_default.py
+++ b/config/train_default.py
@@ -27,7 +27,6 @@ bias = False
 
 dag_depth = 0
 dag_hidden_dim = 16
-dag_num_ops = 5
 
 learning_rate = 6e-4
 max_iters = 0

--- a/tests/test_dag_model.py
+++ b/tests/test_dag_model.py
@@ -40,8 +40,8 @@ def test_dag_node_growth_regression(monkeypatch):
             return input1, input2, op_weights
 
     monkeypatch.setattr(dag_model, "op_funcs", dag_model.op_funcs[:2])
-    dag = DifferentiableDAG(hidden_dim=4, num_ops=2, num_steps=2)
-    dag.controller = DummyController(4, 2)
+    dag = DifferentiableDAG(hidden_dim=4, num_steps=2)
+    dag.controller = DummyController(4)
     ctx = torch.zeros(1, 4)
     out = dag([torch.ones(1, 4)], ctx, ctx)
     assert out.shape == (1, 3, 4)
@@ -209,7 +209,7 @@ def test_post_dag_block_called(monkeypatch):
 
 def test_step_contexts_added(monkeypatch):
     monkeypatch.setattr(dag_model, "op_funcs", dag_model.op_funcs[:2])
-    dag = DifferentiableDAG(hidden_dim=4, num_ops=2, num_steps=3)
+    dag = DifferentiableDAG(hidden_dim=4, num_steps=3)
 
     step_vals = torch.stack([torch.full((4,), float(i)) for i in range(3)])
     dag.step_emb = nn.Embedding.from_pretrained(step_vals, freeze=True)
@@ -221,7 +221,7 @@ def test_step_contexts_added(monkeypatch):
             captured.append((operand_ctx.clone(), op_ctx.clone()))
             return nodes[:, 0, :], nodes[:, 0, :], torch.tensor([[1.0, 0.0]])
 
-    dag.controller = RecController(4, 2)
+    dag.controller = RecController(4)
 
     init = [torch.zeros(1, 4), torch.ones(1, 4)]
     op_ctx = torch.ones(1, 4)

--- a/tests/test_daggpt_bugs.py
+++ b/tests/test_daggpt_bugs.py
@@ -6,7 +6,7 @@ from dag_model import DAGGPT, DAGGPTConfig, DAGController
 
 def test_controller_selects_distinct_inputs():
     torch.manual_seed(0)
-    controller = DAGController(hidden_dim=4, num_ops=5)
+    controller = DAGController(hidden_dim=4)
     nodes = torch.randn(1, 3, 4)
     ctx = torch.zeros(1, 4)
     input1, input2, _ = controller(nodes, ctx, ctx)

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -87,6 +87,7 @@ def test_start_cloud_training_default_config(monkeypatch):
 
 def test_visualize_dag_attention(tmp_path):
     from dag_model import DAGGPT, DAGGPTConfig, DAGController
+    import dag_model
     import torch
 
     class DummyController(DAGController):
@@ -94,7 +95,9 @@ def test_visualize_dag_attention(tmp_path):
             self.last_attn = torch.tensor([[1.0, 0.0]])
             input1 = nodes[:, 0, :]
             input2 = nodes[:, 1, :]
-            self.last_op_weights = torch.tensor([[0.0, 0.0, 1.0, 0.0, 0.0]])
+            weights = torch.zeros(1, len(dag_model.op_funcs))
+            weights[0, 2] = 1.0
+            self.last_op_weights = weights
             return input1, input2, self.last_op_weights
 
     prompt = "2 3"
@@ -108,7 +111,7 @@ def test_visualize_dag_attention(tmp_path):
         dag_depth=1,
     )
     model = DAGGPT(cfg)
-    model.dag.controller = DummyController(cfg.n_embd, cfg.dag_num_ops)
+    model.dag.controller = DummyController(cfg.n_embd)
     out_path = tmp_path / "viz.png"
     class SimpleTokenizer:
         def encode(self, text):

--- a/train.py
+++ b/train.py
@@ -64,7 +64,6 @@ class TrainConfig:
 
     dag_depth: int = 0
     dag_hidden_dim: int = 16
-    dag_num_ops: int = 5
 
     learning_rate: float = 6e-4
     max_iters: int = 600000
@@ -159,7 +158,6 @@ dropout = cfg.dropout
 bias = cfg.bias
 dag_depth = cfg.dag_depth
 dag_hidden_dim = cfg.dag_hidden_dim
-dag_num_ops = cfg.dag_num_ops
 learning_rate = cfg.learning_rate
 max_iters = cfg.max_iters
 weight_decay = cfg.weight_decay
@@ -257,7 +255,7 @@ if meta_path.exists():
 model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,
                   bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line
 if dag_depth > 0:
-    model_args.update(dag_depth=dag_depth, dag_hidden_dim=dag_hidden_dim, dag_num_ops=dag_num_ops)
+    model_args.update(dag_depth=dag_depth, dag_hidden_dim=dag_hidden_dim)
 
 ModelConfig = DAGGPTConfig if dag_depth > 0 else GPTConfig
 ModelClass = DAGGPT if dag_depth > 0 else GPT


### PR DESCRIPTION
## Summary
- expand DAG operations with power, log, max, and min
- remove `num_ops` argument from DAG components and config
- update training scripts, configs, and tests
- document new operations in README

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdd9a65988329958e526da4a71ab5