### PR TITLE
Require API keys for cloud and wandb usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # nanoGPT DAG Experiment
 
-This repository extends [nanoGPT](https://github.com/karpathy/nanoGPT) with a differentiable
-DAG module for lightweight numeric reasoning. The DAG controller attends over
-previous nodes and chooses simple operations such as addition and subtraction
-(see `dag_model.py`). The `DAGGPT` model runs the transformer while preserving a
-copy of the input embeddings. A separate DAG stream operates on this copy and
-its final node is decoded back to a numeric token.
+This repository adds a differentiable DAG layer to [nanoGPT](https://github.com/karpathy/nanoGPT)
+for lightweight numeric reasoning. The DAG controller attends over earlier nodes
+and selects simple arithmetic operations (see `dag_model.py`). `DAGGPT` keeps a
+copy of the input embeddings for the DAG stream and mixes the resulting value
+back with the transformer state before decoding the final token.
 The module implements basic ops (`add`, `multiply`, `subtract`, `divide`, `identity`,
 `power`, `log`, `max`, `min`) and learns to compose them via attention.
 The experiment evaluates whether this reasoning layer improves performance on small arithmetic problems.
@@ -90,19 +89,11 @@ pip show runpod
 python3 -c "import runpod; print(runpod.__version__)"
 ```
 
-Configure your API key in code:
-
-```python
-import runpod
-import os
-
-runpod.api_key = os.getenv("RUNPOD_API_KEY")
-```
-
-Launch training in the cloud:
+Set the API key via an environment variable or command line argument. Launch training in the cloud:
 
 ```bash
-python runpod_service.py train config/train_default.py --gpu "NVIDIA A100 40GB PCIe"
+export RUNPOD_API_KEY=YOUR_KEY
+python runpod_service.py train config/train_default.py --gpu "NVIDIA A100 40GB PCIe" --api-key $RUNPOD_API_KEY
 ```
 
 Or run inference using an existing endpoint:

--- a/runpod_service.py
+++ b/runpod_service.py
@@ -22,7 +22,9 @@ class RunpodError(Exception):
     """Custom exception for RunPod operations."""
 
 
-def start_cloud_training(train_args: str, gpu_type: str = DEFAULT_GPU) -> str:
+def start_cloud_training(
+    train_args: str, gpu_type: str = DEFAULT_GPU, api_key: str | None = None
+) -> str:
     """Launch a training job on RunPod and stream status to the console.
 
     Args:
@@ -32,9 +34,9 @@ def start_cloud_training(train_args: str, gpu_type: str = DEFAULT_GPU) -> str:
     Returns:
         The created pod ID.
     """
-    api_key = os.getenv("RUNPOD_API_KEY")
+    api_key = api_key or os.getenv("RUNPOD_API_KEY")
     if not api_key:
-        raise RunpodError("RUNPOD_API_KEY environment variable is required")
+        raise RunpodError("RunPod API key is required")
 
     rp = _get_runpod()
     rp.api_key = api_key
@@ -141,6 +143,7 @@ if __name__ == "__main__":
     t = sub.add_parser("train", help="Start training job")
     t.add_argument("config", help="Training config file")
     t.add_argument("--gpu", default=DEFAULT_GPU, help="GPU type id")
+    t.add_argument("--api-key", help="RunPod API key")
 
     i = sub.add_parser("infer", help="Run inference")
     i.add_argument("prompt", help="Prompt text")
@@ -148,6 +151,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     if args.cmd == "train":
-        start_cloud_training(args.config, args.gpu)
+        start_cloud_training(args.config, args.gpu, api_key=args.api_key)
     else:
         run_inference(args.prompt, args.endpoint)

--- a/train.py
+++ b/train.py
@@ -120,6 +120,8 @@ parser.add_argument("config", nargs="?", default="config/train_default.py")
 parser.add_argument("--use-runpod", action="store_true")
 parser.add_argument("--dag-depth", type=int)
 parser.add_argument("--gpu-type")
+parser.add_argument("--runpod-api-key", help="RunPod API key")
+parser.add_argument("--wandb-api-key", help="Weights & Biases API key")
 args, overrides = parser.parse_known_args()
 
 cfg = TrainConfig()
@@ -135,6 +137,18 @@ _dag_depth_override = args.dag_depth
 _gpu_type_flag = args.gpu_type or runpod_service.DEFAULT_GPU
 config_path = args.config
 config = vars(cfg)
+
+# propagate API keys via environment variables
+if args.runpod_api_key:
+    os.environ["RUNPOD_API_KEY"] = args.runpod_api_key
+if args.wandb_api_key:
+    os.environ["WANDB_API_KEY"] = args.wandb_api_key
+
+# validate required keys
+if args.use_runpod and not os.getenv("RUNPOD_API_KEY"):
+    parser.error("--use-runpod requires a RunPod API key (--runpod-api-key or RUNPOD_API_KEY env var)")
+if cfg.wandb_log and not os.getenv("WANDB_API_KEY"):
+    parser.error("wandb logging enabled but WANDB_API_KEY not set. Provide via --wandb-api-key or environment variable")
 
 # local aliases for config values
 out_dir = cfg.out_dir
@@ -179,7 +193,7 @@ if _use_runpod_flag:
         remote_args += f" {ov}"
     if _dag_depth_override is not None:
         remote_args += f" --dag_depth={_dag_depth_override}"
-    runpod_service.start_cloud_training(remote_args, _gpu_type_flag)
+    runpod_service.start_cloud_training(remote_args, _gpu_type_flag, api_key=os.getenv("RUNPOD_API_KEY"))
     raise SystemExit
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add `--runpod-api-key` and `--wandb-api-key` args to `train.py`
- validate the keys and pass them through to `runpod_service`
- allow `start_cloud_training` to accept an API key
- expose the new argument in the `runpod_service` CLI
- update docs for current DAGGPT behavior and revised RunPod instructions

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe082bdfc83299f9d17af338b1c99