### PR TITLE
Add wandb instructions for RunPod

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Set the API key via an environment variable or command line argument. Launch tra
 ```bash
 export RUNPOD_API_KEY=YOUR_KEY
 python runpod_service.py train config/train_default.py --gpu "NVIDIA A100 40GB PCIe" --api-key $RUNPOD_API_KEY
+
+To enable Weights & Biases logging, provide your ``WANDB_API_KEY`` and use the RunPod training config:
+
+```bash
+export RUNPOD_API_KEY=YOUR_KEY
+export WANDB_API_KEY=YOUR_WANDB_KEY
+python runpod_service.py train config/train_daggpt_runpod.py --gpu "NVIDIA A100 40GB PCIe" --api-key $RUNPOD_API_KEY
 ```
 
 Or run inference using an existing endpoint:


### PR DESCRIPTION
## Summary
- document how to run RunPod training with WANDB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe64028c483299db2168917368fa7