### PR TITLE
Fix GradScaler deprecation warning

### DIFF
--- a/train.py
+++ b/train.py
@@ -325,7 +325,12 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+try:
+    scaler = torch.amp.GradScaler(device_type=device_type,
+                                  enabled=(dtype == 'float16'))
+except AttributeError:
+    # fall back for older PyTorch versions
+    scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary
- update GradScaler initialization to use `torch.amp.GradScaler` when available
- fall back to old `torch.cuda.amp.GradScaler` for older PyTorch versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c2053a10832984a354a75ba58425