### PR TITLE
Add runtime Python version check

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -6,6 +6,10 @@ from contextlib import nullcontext
 import numpy as np
 import time
 import torch
+
+from python_version_check import check_python_version
+
+check_python_version()
 from model import GPTConfig, GPT
 
 # -----------------------------------------------------------------------------

--- a/compare_checkpoints.py
+++ b/compare_checkpoints.py
@@ -4,6 +4,10 @@ import tiktoken
 from model import GPT, GPTConfig
 from dag_model import DAGGPT, DAGGPTConfig
 
+from python_version_check import check_python_version
+
+check_python_version()
+
 
 def load_model(ckpt_path, device):
     ckpt = torch.load(ckpt_path, map_location=device)

--- a/python_version_check.py
+++ b/python_version_check.py
@@ -1,0 +1,13 @@
+import sys
+
+MIN_VERSION = (3, 10)
+
+
+def check_python_version() -> None:
+    """Raise ``RuntimeError`` if the running Python is too old."""
+    if sys.version_info < MIN_VERSION:
+        required = ".".join(map(str, MIN_VERSION))
+        raise RuntimeError(
+            f"Python {required}+ is required, found {sys.version.split()[0]}"
+        )
+

--- a/runpod_service.py
+++ b/runpod_service.py
@@ -2,6 +2,10 @@ import os
 import time
 from typing import Sequence
 
+from python_version_check import check_python_version
+
+check_python_version()
+
 runpod = None
 
 

--- a/sample.py
+++ b/sample.py
@@ -8,6 +8,10 @@ import torch
 import tiktoken
 from model import GPTConfig, GPT
 
+from python_version_check import check_python_version
+
+check_python_version()
+
 # -----------------------------------------------------------------------------
 init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
 out_dir = 'out' # ignored if init_from is not 'resume'

--- a/train.py
+++ b/train.py
@@ -18,6 +18,10 @@ $ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123
 
 import os
 from pathlib import Path
+
+from python_version_check import check_python_version
+
+check_python_version()
 import time
 import math
 import pickle


### PR DESCRIPTION
## Summary
- ensure Python >=3.10 is used when running core scripts
- provide a helper `check_python_version` utility

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c23ce3a48329928bd3fec257b55c