### PR TITLE
Fix default RunPod GPU type

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Set the API key via an environment variable or command line argument. Launch tra
 
 ```bash
 export RUNPOD_API_KEY=YOUR_KEY
-python runpod_service.py train config/train_default.py --gpu "NVIDIA A100 40GB PCIe" --api-key $RUNPOD_API_KEY
+python runpod_service.py train config/train_default.py --gpu "NVIDIA A100 80GB PCIe" --api-key $RUNPOD_API_KEY
 
 To enable Weights & Biases logging, provide your ``WANDB_API_KEY`` and use the RunPod training config:
 
 ```bash
 export RUNPOD_API_KEY=YOUR_KEY
 export WANDB_API_KEY=YOUR_WANDB_KEY
-python runpod_service.py train config/train_daggpt_runpod.py --gpu "NVIDIA A100 40GB PCIe" --api-key $RUNPOD_API_KEY
+python runpod_service.py train config/train_daggpt_runpod.py --gpu "NVIDIA A100 80GB PCIe" --api-key $RUNPOD_API_KEY
 ```
 
 Or run inference using an existing endpoint:

--- a/config/train_gpt2.py
+++ b/config/train_gpt2.py
@@ -1,4 +1,4 @@
-# config for training GPT-2 (124M) down to very nice loss of ~2.85 on 1 node of 8X A100 40GB
+# config for training GPT-2 (124M) down to very nice loss of ~2.85 on 1 node of 8X A100 80GB
 # launch as the following (e.g. in a screen session) and wait ~5 days:
 # $ torchrun --standalone --nproc_per_node=8 train.py config/train_gpt2.py
 

--- a/runpod_service.py
+++ b/runpod_service.py
@@ -19,7 +19,7 @@ def _get_runpod():
 
 
 DEFAULT_IMAGE = "runpod/pytorch:2.2.1-cuda12.1-devel"
-DEFAULT_GPU = "NVIDIA A100 40GB PCIe"
+DEFAULT_GPU = "NVIDIA A100 80GB PCIe"
 
 
 class RunpodError(Exception):


### PR DESCRIPTION
## Summary
- update default RunPod GPU to `NVIDIA A100 80GB PCIe`
- update README to mention the correct GPU type
- fix a comment that referenced the old A100 size

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c82975c08329b1402be177ee676f