### PR TITLE
Fix RunPod default image

### DIFF
--- a/runpod_service.py
+++ b/runpod_service.py
@@ -19,7 +19,7 @@ def _get_runpod():
     return runpod
 
 
-DEFAULT_IMAGE = "runpod/pytorch:2.2.1-cuda12.1-devel"
+DEFAULT_IMAGE = "runpod/pytorch:2.2.1-py3.10-cuda12.1.1-devel-ubuntu22.04"
 DEFAULT_GPU = "NVIDIA A100 80GB PCIe"
 
 


### PR DESCRIPTION
## Summary
- use a valid RunPod image tag in `runpod_service.py`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d02aa83083298186817c3c1f7f44