### PR TITLE
Improve RunPod polling reliability

### DIFF
--- a/runpod_service.py
+++ b/runpod_service.py
@@ -64,7 +64,13 @@ def start_cloud_training(
 
     while True:
         info = rp.get_pod(pod_id)
-        status = info.get("desiredStatus") or info.get("podStatus") or info.get("state")
+        if not info:
+            raise RunpodError("RunPod API returned no status information")
+        status = (
+            info.get("desiredStatus")
+            or info.get("podStatus")
+            or info.get("state")
+        )
         print(f"Training status: {status}")
         if status in {"COMPLETED", "STOPPED", "FAILED", "TERMINATED"}:
             break


### PR DESCRIPTION
## Summary
- fail gracefully when pod status isn't available
- update tests (none needed)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850de2ab11883298ed3e28e1a7b4006