### PR TITLE
Fix RunPod training path

### DIFF
--- a/runpod_service.py
+++ b/runpod_service.py
@@ -48,13 +48,20 @@ def start_cloud_training(
     rp = _get_runpod()
     rp.api_key = api_key
 
+    args_list = train_args.split()
+    if args_list:
+        cfg_path = args_list[0]
+        if not os.path.isabs(cfg_path):
+            args_list[0] = f"/workspace/{cfg_path}"
+    train_args = " ".join(args_list)
+
     pod = rp.create_pod(
         name="nanogpt-training",
         image_name=DEFAULT_IMAGE,
         gpu_type_id=gpu_type,
         gpu_count=1,
         start_ssh=True,
-        docker_args=f"python train.py {train_args}",
+        docker_args=f"python /workspace/train.py {train_args}",
     )
     pod_id = pod.get("id")
     if not pod_id:

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -53,7 +53,8 @@ def test_start_cloud_training(monkeypatch):
     monkeypatch.setattr(rp.time, "sleep", lambda x: None)
     pod_id = rp.start_cloud_training("config.py")
     assert pod_id == "pod123"
-    assert "docker_args" in created and "config.py" in created["docker_args"]
+    args = created.get("docker_args", "")
+    assert "/workspace/train.py" in args and "/workspace/config.py" in args
 
 
 def test_start_cloud_training_default_config(monkeypatch):
@@ -82,7 +83,8 @@ def test_start_cloud_training_default_config(monkeypatch):
     monkeypatch.setattr(rp.time, "sleep", lambda x: None)
     pod_id = rp.start_cloud_training("config/train_chatgpt2.py")
     assert pod_id == "pod123"
-    assert "config/train_chatgpt2.py" in created.get("docker_args", "")
+    args = created.get("docker_args", "")
+    assert "/workspace/train.py" in args and "/workspace/config/train_chatgpt2.py" in args
 
 
 def test_visualize_dag_attention(tmp_path):


### PR DESCRIPTION
## Summary
- correct path to `train.py` when launching RunPod jobs
- ensure config files use absolute path `/workspace/...`
- update RunPod tests

## Testing
- `pytest tests/test_runpod_service.py::test_run_inference tests/test_runpod_service.py::test_start_cloud_training tests/test_runpod_service.py::test_start_cloud_training_default_config -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e35962a4832996bb317075ef80b4