### PR TITLE
Install Lambda Guest Agent in launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ export WANDB_API_KEY=YOUR_WANDB_KEY
 python lambda_service.py train config/train_daggpt_lambda.py
 ```
 
+The launch script installs Lambda's Guest Agent so GPU metrics show up on your Cloud dashboard. It runs the following command before starting training:
+
+```bash
+curl -L https://lambdalabs-guest-agent.s3.us-west-2.amazonaws.com/scripts/install.sh | sudo bash
+```
+
 ### Troubleshooting tips
 
 * **Authentication errors** – confirm the ``LAMBDA_API_KEY`` is valid.

--- a/lambda_service.py
+++ b/lambda_service.py
@@ -44,7 +44,11 @@ def start_cloud_training(
             args_list[0] = f"/workspace/{cfg_path}"
     train_args = " ".join(args_list)
 
-    user_data = f"#!/bin/bash\ncd /workspace && python train.py {train_args}\n"
+    user_data = (
+        "#!/bin/bash\n"
+        "curl -L https://lambdalabs-guest-agent.s3.us-west-2.amazonaws.com/scripts/install.sh | sudo bash\n"
+        f"cd /workspace && python train.py {train_args}\n"
+    )
 
     payload = {
         "region_name": region,

--- a/tests/test_lambda_service.py
+++ b/tests/test_lambda_service.py
@@ -38,6 +38,7 @@ def test_start_cloud_training(monkeypatch):
     inst_id = ls.start_cloud_training("config.py")
     assert inst_id == "inst123"
     assert "/workspace/config.py" in created["payload"].get("user_data", "")
+    assert "guest-agent" in created["payload"].get("user_data", "")
 
 
 def test_start_cloud_training_default_config(monkeypatch):
@@ -63,6 +64,7 @@ def test_start_cloud_training_default_config(monkeypatch):
     inst_id = ls.start_cloud_training("config/train_chatgpt2.py")
     assert inst_id == "inst123"
     assert "/workspace/config/train_chatgpt2.py" in created["payload"].get("user_data", "")
+    assert "guest-agent" in created["payload"].get("user_data", "")
 
 
 def test_visualize_dag_attention(tmp_path):

--- a/train.py
+++ b/train.py
@@ -330,9 +330,10 @@ model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
 try:
-    scaler = torch.amp.GradScaler(device_type=device_type,
-                                  enabled=(dtype == 'float16'))
-except AttributeError:
+    scaler = torch.amp.GradScaler(
+        device_type=device_type, enabled=(dtype == "float16")
+    )
+except (AttributeError, TypeError):
     # fall back for older PyTorch versions
     scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
 


### PR DESCRIPTION
## Summary
- install Lambda Guest Agent before starting training instances
- mention Guest Agent installation in README
- verify user-data contains guest-agent commands in tests
- handle newer PyTorch GradScaler without `device_type` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f6cf1600832989c8e81d1cddc863