### PR TITLE
Enable W&B log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,16 @@ python lambda_service.py train config/train_daggpt_lambda.py
 * **Authentication errors** – confirm the ``LAMBDA_API_KEY`` is valid.
 * **Storage full** – check disk usage with ``df -h`` and remove large files.
 * **Leaked API keys** – revoke the compromised key from the console.
+
+### Viewing Weights & Biases logs
+
+When ``wandb_log`` is enabled (the default in ``config/train_default.py`` or via
+an override), the training script calls ``wandb.init`` with
+``wandb_project`` and ``wandb_run_name``. This automatically creates the project
+if it does not exist or attaches to it if it already exists.
+
+After initialization, ``train.py`` prints ``W&B run URL: <link>`` where ``<link>``
+is a direct link to the run such as
+``https://wandb.ai/<user>/<project>/runs/<run-id>``. Open this address in your
+browser to monitor metrics, loss curves and system stats live. You can also find
+the run from your dashboard at ``https://wandb.ai``.

--- a/config/train_default.py
+++ b/config/train_default.py
@@ -9,7 +9,7 @@ eval_only = False
 always_save_checkpoint = True
 init_from = "scratch"
 
-wandb_log = False
+wandb_log = True
 wandb_project = "owt"
 wandb_run_name = "gpt2"
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -53,6 +53,7 @@ def test_train_script_runs(tmp_path: Path, batch_size: int):
         "--n_head=1",
         "--n_embd=32",
         "--block_size=32",
+        "--wandb_log=False",
     ]
     # Run the training script in ``tmp_path`` so it picks up the synthetic dataset
     subprocess.check_call(cmd, cwd=tmp_path)

--- a/train.py
+++ b/train.py
@@ -384,7 +384,8 @@ def get_lr(it: int) -> float:
 # logging
 if wandb_log and master_process:
     import wandb
-    wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+    run = wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+    print(f"W&B run URL: {run.url}")
 
 # training loop
 X, Y = get_batch('train') # fetch the very first batch


### PR DESCRIPTION
## Summary
- enable `wandb_log` in the default training config
- show Weights & Biases run URL after `wandb.init`
- clarify in README how to view W&B logs

## Testing
- `pytest -q` *(fails: GradScaler.__init__() got an unexpected keyword argument 'device_type')*

------
https://chatgpt.com/codex/tasks/task_e_6850f7e24a648329afbf8b2ae269b568