### PR TITLE
Add interactive cloud training via SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ source env/bin/activate
 pip install requests
 ```
 
-Launch training in the cloud using your API and SSH key:
+Launch training in the cloud using your API and SSH key. The helper script now
+opens an SSH session and runs the training command interactively so you can
+watch the logs directly:
 
 ```bash
 export LAMBDA_API_KEY=YOUR_KEY
@@ -99,7 +101,7 @@ export WANDB_API_KEY=YOUR_WANDB_KEY
 python lambda_service.py train config/train_daggpt_lambda.py
 ```
 
-The launch script installs Lambda's Guest Agent so GPU metrics show up on your Cloud dashboard. It runs the following command before starting training:
+The launch script installs Lambda's Guest Agent so GPU metrics show up on your Cloud dashboard. It runs the following command before you SSH in to run training:
 
 ```bash
 curl -L https://lambdalabs-guest-agent.s3.us-west-2.amazonaws.com/scripts/install.sh | sudo bash


### PR DESCRIPTION
## Summary
- update `lambda_service.start_cloud_training` to wait for IP, SSH in and run training
- tweak README for new workflow
- update tests for new behavior

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851025c24548329bf2e55f36fe42f96