### PR TITLE
Clean up runpod imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -1,4 +1,3 @@
-import types
 import sys
 from pathlib import Path
 
@@ -31,6 +30,7 @@ def test_start_cloud_training(monkeypatch):
 
     monkeypatch.setenv("RUNPOD_API_KEY", "key")
     monkeypatch.setattr(rp.runpod, "create_pod", fake_create_pod)
+    monkeypatch.setattr(rp.runpod, "get_gpus", lambda: [{"id": "gpu123", "displayName": rp.DEFAULT_GPU_TYPE}])
     monkeypatch.setattr(rp, "get_pod_ssh_ip_port", fake_ip_port)
     monkeypatch.setattr(rp, "SSHConnection", DummySSH)
 
@@ -39,6 +39,7 @@ def test_start_cloud_training(monkeypatch):
     assert commands['value'] == [
         "cd /workspace && python train.py /workspace/config.py"
     ]
+    assert created['params']['gpu_type_id'] == 'gpu123'
 
 
 def test_visualize_dag_attention(tmp_path):


### PR DESCRIPTION
## Summary
- drop fallback imports for when the `runpod` package isn't installed
- simplify RunPod service tests now that dependencies are available

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685110556ec88329a77bd16fe7278e6e