### PR TITLE
Improve runpod startup logging and require wandb

### DIFF
--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -13,6 +13,22 @@ def test_start_cloud_training(monkeypatch):
         return {"id": "pod123"}
 
     monkeypatch.setenv("RUNPOD_API_KEY", "key")
+    monkeypatch.setenv("WANDB_API_KEY", "dummy")
+
+    class DummyWandb:
+        class util:
+            @staticmethod
+            def generate_id():
+                return "test-id"
+
+        class Api:
+            def __call__(self):
+                class A:
+                    def viewer(self):
+                        return {"entity": "tester"}
+
+                return A()
+    monkeypatch.setitem(sys.modules, "wandb", DummyWandb())
     monkeypatch.setattr(rp.runpod, "create_pod", fake_create_pod)
     monkeypatch.setattr(
         rp.runpod,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -2,6 +2,7 @@ import pickle
 import subprocess
 import sys
 from pathlib import Path
+import os
 
 import numpy as np
 
@@ -54,7 +55,8 @@ def test_train_script_runs(tmp_path: Path, batch_size: int):
         "--n_head=1",
         "--n_embd=32",
         "--block_size=32",
-        "--wandb_log=False",
     ]
-    # Run the training script in ``tmp_path`` so it picks up the synthetic dataset
-    subprocess.check_call(cmd, cwd=tmp_path)
+    env = os.environ.copy()
+    env["WANDB_API_KEY"] = "dummy"
+    env["WANDB_MODE"] = "offline"
+    subprocess.check_call(cmd, cwd=tmp_path, env=env)

--- a/train.py
+++ b/train.py
@@ -51,7 +51,7 @@ class TrainConfig:
     always_save_checkpoint: bool = True
     init_from: str = "scratch"
 
-    wandb_log: bool = False
+    wandb_log: bool = True
     wandb_project: str = "owt"
     wandb_run_name: str = "gpt2"
 
@@ -153,6 +153,8 @@ if args.use_runpod and not os.getenv("RUNPOD_API_KEY"):
     parser.error(
         "--use-runpod requires a RunPod API key (--runpod-api-key or RUNPOD_API_KEY env var)"
     )
+if not cfg.wandb_log:
+    parser.error("wandb logging is required and cannot be disabled")
 if cfg.wandb_log and not os.getenv("WANDB_API_KEY"):
     parser.error(
         "wandb logging enabled but WANDB_API_KEY not set. Provide via --wandb-api-key or environment variable"


### PR DESCRIPTION
## Summary
- require wandb logging by default and error if disabled
- inject WANDB info into runpod pods
- print pod startup info including wandb URL
- update tests to provide dummy wandb settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511daeb3b083298b511750782f5c07