### PR TITLE
Sync wandb project with pod name

### DIFF
--- a/tests/test_runpod_service.py
+++ b/tests/test_runpod_service.py
@@ -25,7 +25,7 @@ def test_start_cloud_training(monkeypatch):
     assert created["params"]["gpu_type_id"] == "gpu123"
     assert created["params"]["start_ssh"] is False
     expected_cmd = (
-        f"git clone {rp.REPO_URL} repo && cd repo && python train.py /workspace/config.py"
+        f"git clone {rp.REPO_URL} repo && cd repo && python train.py /workspace/config.py --wandb_project={rp.POD_NAME}"
     )
     assert created["params"]["docker_args"] == expected_cmd
 


### PR DESCRIPTION
## Summary
- clean up RunPod helper
- set the wandb project to the same name as the pod
- adjust unit tests

## Testing
- `pytest tests/test_runpod_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851270135ec8329b32cbbf207f3c6a2